### PR TITLE
annotation let's -> annotation lets

### DIFF
--- a/index.html.haml
+++ b/index.html.haml
@@ -158,7 +158,7 @@ layout: base
 .row
   .span4
     :markdown
-      The `@Mapper` annotation <span class="badge badge-info">1</span> marks the interface as mapping interface and let's the MapStruct processor kick in during compilation.
+      The `@Mapper` annotation <span class="badge badge-info">1</span> marks the interface as mapping interface and lets the MapStruct processor kick in during compilation.
 
       The actual mapping method <span class="badge badge-info">2</span> expects the source object as parameter and returns the target object. Its name can be freely chosen.
   .span4


### PR DESCRIPTION
Ah, didn't notice the site project; I thought maybe it was somehow autogenerated from the lib's readme.
