### PR TITLE
#43 Use stable for the stable reference guide / api documentation;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 public
+.idea/

--- a/content/documentation/reference-guide.md
+++ b/content/documentation/reference-guide.md
@@ -12,8 +12,8 @@ parent = "Documentation"
 
 **1.1.0.Final** (November 18th 2016)
 
-* Reference guide: [HTML](/documentation/1.1/reference/html/index.html) | [PDF](/documentation/1.1/reference/pdf/mapstruct-reference-guide.pdf)
-* API documentation: [JavaDoc](/documentation/1.1/api/index.html)
+* Reference guide: [HTML](/documentation/stable/reference/html/index.html) | [PDF](/documentation/stable/reference/pdf/mapstruct-reference-guide.pdf)
+* API documentation: [JavaDoc](/documentation/stable/api/index.html)
 * [Migration notes](https://github.com/mapstruct/mapstruct/wiki/Migration-notes#110final)
 
 **1.0.0.Final** (November 25th 2015)

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,6 +4,21 @@ DIR=$(dirname "$0")
 
 cd $DIR/..
 
+STABLE_VERSION=`grep -e stableVersion config.toml | sed 's/stableVersion = "\([0-9]*\.[0-9]*\).*"/\1/'`
+
+if [[ -z $STABLE_VERSION ]]
+then
+    echo "Could not extract the stable version from the config.toml"
+    exit 1;
+fi
+
+STABLE_VERSION_FOLDER="static/documentation/${STABLE_VERSION}"
+if [[ ! -d ${STABLE_VERSION_FOLDER} ]]
+then
+    echo "The folder with the stable version: ${STABLE_VERSION_FOLDER} could not be found. Please provide a valid version"
+    exit 1;
+fi
+
 if [[ $(git status -s) ]]
 then
     echo "The working directory is dirty. Please commit any pending changes."
@@ -30,5 +45,14 @@ rm public/documentation/index.xml
 rm public/community/index.xml
 rm public/development/index.xml
 
+DESTINATION_STABLE_VERSION="public/documentation/stable"
+echo "Copying the stable documentation from ${STABLE_VERSION_FOLDER} to ${DESTINATION_STABLE_VERSION}"
+cp -r ${STABLE_VERSION_FOLDER} ${DESTINATION_STABLE_VERSION}
+
+echo "Add noindex meta tag to all HTML (backups will be created) files in public/documentation/[0-9]*"
+find public/documentation -type f -regex "public/documentation/[0-9].*" -name "*.html" -exec sed -i.bak "s/<\/head>/<meta name=\"robots\" content=\"noindex\" \/><\/head>/" {} +
+echo "removing all the backups that were created for the previous command"
+find public/documentation -type f -regex "public/documentation/[0-9].*" -name "*.html.bak" -delete
+
 echo "Updating gh-pages branch"
-cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)"
+cd public && git add --all && git commit -m "Publishing to gh-pages. Using stable version folder ${STABLE_VERSION_FOLDER}. (publish.sh)"


### PR DESCRIPTION
Insert robots noindex to all the other reference guide / api documentation

Is this something that we want to achieve? Do we want only the stable version to be indexed?

For the stable version I found a way to just insert the robots `noindex` meta tag and also just copy it when we do the publish. The only downside is that we are not going to be able to open the reference guide when we run hugo locally (as the stable folder is created during publishing).