### PR TITLE
#44 Add google analytics to the reference guide and the API docs before publishing

### DIFF
--- a/scripts/analytics_snippet.txt
+++ b/scripts/analytics_snippet.txt
@@ -1,0 +1,10 @@
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-41136939-1', 'auto');
+ga('send', 'pageview');
+</script>
+</head>

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -34,6 +34,13 @@ then
     exit 1;
 fi
 
+GOOGLE_ANALYTICS_ID=`grep -e googleAnalytics config.toml | sed 's/googleAnalytics = "\(.*\)"/\1/'`
+
+if [[ -z $GOOGLE_ANALYTICS_ID ]]
+then
+    echo "Could not extract the Google Analytics ID from the config.toml"
+    exit 1;
+fi
 
 if [[ $(git status -s) ]]
 then
@@ -76,6 +83,10 @@ cp -r ${DEV_VERSION_FOLDER} ${DESTINATION_DEV_VERSION}
 # find public/documentation -type f -regex "public/documentation/[0-9].*" -name "*.html" -exec sed -i.bak "s/<\/head>/<meta name=\"robots\" content=\"noindex\" \/><\/head>/" {} +
 # echo "removing all the backups that were created for the previous command"
 # find public/documentation -type f -regex "public/documentation/[0-9].*" -name "*.html.bak" -delete
+
+echo "Inserting analytics snippet"
+find public/documentation -type f -regex "\(public/documentation/[0-9]\|${DESTINATION_STABLE_VERSION}/\|${DESTINATION_DEV_VERSION}/\).*" -name "*.html" -exec sed -i.bak -e '/^\s*<\/head>/ {' -e 'r scripts/analytics_snippet.txt' -e 'd' -e '}' {} +
+find public/documentation -type f -regex "\(public/documentation/[0-9]\|${DESTINATION_STABLE_VERSION}/\|${DESTINATION_DEV_VERSION}/\).*" -name "*.html.bak" -delete
 
 echo "Updating gh-pages branch"
 cd public && git add --all && git commit -m "Publishing to gh-pages. Using stable version folder ${STABLE_VERSION_FOLDER}. (publish.sh)"


### PR DESCRIPTION
I was focusing on inserting the analytics snippet at the end of the `head`.

I tried several ways to implement this:

* Using sed and output from a file so we don't need to escape the script -> If you want to read from a file sed can only insert after a matching pattern. Maybe we can insert it after the `title` in the `head`?
* Using perl -> There were some problems when trying to use inplace editing
* Using awk -> MacOS and Linux do not have the same installations and thus could not use inplace

If it is OK to insert the snippet after the title I would prefer to use that. That way we can store the snippet in a text file and it will be inserted with line breaks and we won't have to escape the special regex characters.