### PR TITLE
Fix broken links in TOC of MapStruct site FAQ

### DIFF
--- a/themes/mapstruct/layouts/shortcodes/faq_question.html
+++ b/themes/mapstruct/layouts/shortcodes/faq_question.html
@@ -1,4 +1,4 @@
-<h2 id="{{ .Get 0 | plainify | urlize }}">{{ .Get 0 }}</h2>
+<h2 id="{{ .Get 0 | plainify | urlize | lower }}">{{ .Get 0 }}</h2>
 <div>
   {{ .Inner }}
 </div>


### PR DESCRIPTION
The links in the table of contents of the frequency asked questions
(https://mapstruct.org/faq/) in the Mapstruct site seem to be broken.

The problem has to do with the different functions applied against
the H2 headings text in the Hugo shortcode definition
(https://github.com/mapstruct/mapstruct.org/blob/master/themes/mapstruct/layouts/shortcodes/faq_question.html)
and the FAQ TOC partial (https://github.com/mapstruct/mapstruct.org/blob/master/themes/mapstruct/layouts/partials/faq_toc.html).

One possible solution is the one suggested and provide a trailing lower
function in the shortcode definition as well.

A companion change can be done in the core Mapstruct repo to provide the
right values for the constants defined in MessageConstants
(https://github.com/mapstruct/mapstruct/blob/985ca2fe64745607b003c71a87559dfbe8ffe482/processor/src/main/java/org/mapstruct/ap/internal/util/MessageConstants.java#L11-L12).
The change will also affect to several tests.