### PR TITLE
Update ide-support.md

### DIFF
--- a/content/documentation/ide-support.md
+++ b/content/documentation/ide-support.md
@@ -31,7 +31,7 @@ If you are working with a gradle project, then add the folowing plugin to the gr
 {{< prettify >}}
 plugins {
     // Allow configuration calls for setting up the eclipse annotation processing configuration.
-    id 'net.ltgt.apt-eclipse' version "0.21"
+    id "com.diffplug.eclipse.apt" version "3.36.2"
 }
 {{< /prettify >}}
 You can then generate the required eclipse project information by calling `gradle eclipseJdtApt eclipseFactorypath eclipseJdt`

--- a/content/documentation/ide-support.md
+++ b/content/documentation/ide-support.md
@@ -31,7 +31,7 @@ If you are working with a gradle project, then add the folowing plugin to the gr
 {{< prettify >}}
 plugins {
     // Allow configuration calls for setting up the eclipse annotation processing configuration.
-    id "com.diffplug.eclipse.apt" version "3.36.2"
+    id 'com.diffplug.eclipse.apt' version '3.37.2'
 }
 {{< /prettify >}}
 You can then generate the required eclipse project information by calling `gradle eclipseJdtApt eclipseFactorypath eclipseJdt`


### PR DESCRIPTION
Due to the stopped maintaining problem with `net.ltgt.apt-eclipse` plugin, it displays compile error for IntelliJ or Eclipse.  (Ref: https://stackoverflow.com/q/67082576/4729203)  
Original documentation of this plugin recommending to use `com.diffplug.eclipse.apt`. (Ref: https://github.com/tbroyer/gradle-apt-plugin#gradle-apt-plugin)  

> If you're using Eclipse, please migrate to the com.diffplug.eclipse.apt plugin, which is a (maintained) fork of net.ltgt.apt-eclipse.